### PR TITLE
Add missing scope and functionality to log out of the external service

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -57,4 +57,28 @@ class Provider extends AbstractProvider
             'grant_type' => 'authorization_code',
         ]);
     }
+
+    /**
+     * {@inheritdoc}
+    */
+    protected function getCodeFields($state = null)
+    {
+        return array_merge(parent::getCodeFields($state), [
+            'scope' => 'openid',
+        ]);
+    }
+
+    /**
+     *  Get the endsession endpoint URL.
+     */
+    public function getLogoutUrl($idToken, $endpointUri, $redirectUri)
+    {
+        $params = http_build_query(array_filter([
+            'id_token_hint'            => $idToken,
+            'post_logout_redirect_uri' => $redirectUri,
+        ]));
+
+        return "$endpointUri?$params";
+    }
+
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ return Socialite::driver('dataporten')->redirect();
 End session with your application AND dataporten example.
 
 ```php
-$IdToken = auth()->user()->feide_id_token;
+$IdToken = auth()->user()->dataporten_id_token;
 $endpointUri = env('DATAPORTEN_ENDSESSION_ENDPOINT');
 $redirectUri = env('DATAPORTEN_LOGOUT_REDIRECT_URI');
 $logout_uri = Socialite::driver('dataporten')->getLogoutUrl($IdToken, $endpointUri, $redirectUri);

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ You should now be able to use the provider like you would regularly use Socialit
 return Socialite::driver('dataporten')->redirect();
 ```
 
-End session with your application AND dataporten example.
+End session for application AND dataporten example.
 
 ```php
-$IdToken = auth()->user()->dataporten_id_token;
+$idToken = auth()->user()->dataporten_id_token;
 $endpointUri = env('DATAPORTEN_ENDSESSION_ENDPOINT');
 $redirectUri = env('DATAPORTEN_LOGOUT_REDIRECT_URI');
-$logout_uri = Socialite::driver('dataporten')->getLogoutUrl($IdToken, $endpointUri, $redirectUri);
+$logoutUri = Socialite::driver('dataporten')->getLogoutUrl($idToken, $endpointUri, $redirectUri);
 
 Auth::guard('web')->logout();
 
@@ -55,8 +55,8 @@ $request->session()->invalidate();
 
 $request->session()->regenerateToken();
 
-if($IdToken) {
-    return redirect()->away($logout_uri);
+if($idToken) {
+    return redirect()->away($logoutUri);
 }
 
 return redirect('/');

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 ### Add configuration to `config/services.php`
 
 ```php
-'dataporten' => [    
-  'client_id' => env('DATAPORTEN_CLIENT_ID'),  
-  'client_secret' => env('DATAPORTEN_CLIENT_SECRET'),  
-  'redirect' => env('DATAPORTEN_REDIRECT_URI') 
+'dataporten' => [
+  'client_id' => env('DATAPORTEN_CLIENT_ID'),
+  'client_secret' => env('DATAPORTEN_CLIENT_SECRET'),
+  'redirect' => env('DATAPORTEN_REDIRECT_URI')
 ],
 ```
 
@@ -39,4 +39,25 @@ You should now be able to use the provider like you would regularly use Socialit
 
 ```php
 return Socialite::driver('dataporten')->redirect();
+```
+
+End session with your application AND dataporten example.
+
+```php
+$IdToken = auth()->user()->feide_id_token;
+$endpointUri = env('DATAPORTEN_ENDSESSION_ENDPOINT');
+$redirectUri = env('DATAPORTEN_LOGOUT_REDIRECT_URI');
+$logout_uri = Socialite::driver('dataporten')->getLogoutUrl($IdToken, $endpointUri, $redirectUri);
+
+Auth::guard('web')->logout();
+
+$request->session()->invalidate();
+
+$request->session()->regenerateToken();
+
+if($IdToken) {
+    return redirect()->away($logout_uri);
+}
+
+return redirect('/');
 ```

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ End session for application AND dataporten example.
 
 ```php
 $idToken = auth()->user()->dataporten_id_token;
-$endpointUri = env('DATAPORTEN_ENDSESSION_ENDPOINT');
-$redirectUri = env('DATAPORTEN_LOGOUT_REDIRECT_URI');
-$logoutUri = Socialite::driver('dataporten')->getLogoutUrl($idToken, $endpointUri, $redirectUri);
 
 Auth::guard('web')->logout();
 
@@ -56,6 +53,9 @@ $request->session()->invalidate();
 $request->session()->regenerateToken();
 
 if($idToken) {
+    $endpointUri = env('DATAPORTEN_ENDSESSION_ENDPOINT');
+    $redirectUri = env('DATAPORTEN_LOGOUT_REDIRECT_URI');
+    $logoutUri = Socialite::driver('dataporten')->getLogoutUrl($idToken, $endpointUri, $redirectUri);
     return redirect()->away($logoutUri);
 }
 


### PR DESCRIPTION
Added missing scope "openid". 
If it's not in the request you won't be provided with "id_token".

"id_token" is needed for logout functionality which also has been added. 
[Relevant docs](https://docs.feide.no/service_providers/manage/openid_connect/redir_etter_logout.html)

